### PR TITLE
insertTextByPath should replace marks on the inserted text with the o…

### DIFF
--- a/packages/slate/test/commands/by-key/replace-marks-by-key/different-set-of-marks.js
+++ b/packages/slate/test/commands/by-key/replace-marks-by-key/different-set-of-marks.js
@@ -3,20 +3,15 @@
 import h from '../../../helpers/h'
 
 export default function(editor) {
-  const { anchor } = editor.value.selection
-
-  editor.replaceTextByKey(anchor.key, anchor.offset, 3, 'cat is cute', [
-    { type: 'italic' },
-  ])
+  editor.replaceMarksByKey('a', 0, 2, [{ type: 'italic' }])
 }
 
 export const input = (
   <value>
     <document>
       <paragraph>
-        Meow,{' '}
-        <b>
-          <cursor />word.
+        <b key="a" thing="value">
+          word
         </b>
       </paragraph>
     </document>
@@ -27,10 +22,8 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        Meow, <i>cat is cute</i>
-        <b>
-          <cursor />d.
-        </b>
+        <i>wo</i>
+        <b thing="value">rd</b>
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/by-key/replace-marks-by-key/empty-set.js
+++ b/packages/slate/test/commands/by-key/replace-marks-by-key/empty-set.js
@@ -3,20 +3,15 @@
 import h from '../../../helpers/h'
 
 export default function(editor) {
-  const { anchor } = editor.value.selection
-
-  editor.replaceTextByKey(anchor.key, anchor.offset, 3, 'cat is cute', [
-    { type: 'italic' },
-  ])
+  editor.replaceMarksByKey('a', 0, 2, [])
 }
 
 export const input = (
   <value>
     <document>
       <paragraph>
-        Meow,{' '}
-        <b>
-          <cursor />word.
+        <b key="a" thing="value">
+          word
         </b>
       </paragraph>
     </document>
@@ -27,10 +22,8 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        Meow, <i>cat is cute</i>
-        <b>
-          <cursor />d.
-        </b>
+        wo
+        <b thing="value">rd</b>
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/by-key/replace-marks-by-key/same-marks-different-data.js
+++ b/packages/slate/test/commands/by-key/replace-marks-by-key/same-marks-different-data.js
@@ -3,10 +3,8 @@
 import h from '../../../helpers/h'
 
 export default function(editor) {
-  const { anchor } = editor.value.selection
-
-  editor.replaceTextByKey(anchor.key, anchor.offset, 3, 'cat is cute', [
-    { type: 'italic' },
+  editor.replaceMarksByKey('a', 0, 2, [
+    { type: 'bold', data: { thing: 'new value' } },
   ])
 }
 
@@ -14,9 +12,8 @@ export const input = (
   <value>
     <document>
       <paragraph>
-        Meow,{' '}
-        <b>
-          <cursor />word.
+        <b key="a" thing="value">
+          word
         </b>
       </paragraph>
     </document>
@@ -27,10 +24,8 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        Meow, <i>cat is cute</i>
-        <b>
-          <cursor />d.
-        </b>
+        <b thing="new value">wo</b>
+        <b thing="value">rd</b>
       </paragraph>
     </document>
   </value>

--- a/packages/slate/test/commands/by-key/replace-text-by-key/replace-with-active-marks-with-data.js
+++ b/packages/slate/test/commands/by-key/replace-text-by-key/replace-with-active-marks-with-data.js
@@ -27,10 +27,7 @@ export const output = (
   <value>
     <document>
       <paragraph>
-        Meow,{' '}
-        <fontSize size={16}>
-          <fontSize size={12}>cat is cute</fontSize>
-        </fontSize>
+        Meow, <fontSize size={16}>cat is cute</fontSize>
         <fontSize size={12}>
           <cursor />d.
         </fontSize>


### PR DESCRIPTION
…nce that are provided

It were trying to add those marks that are passed to the function to the existing once,
but it should replace them instead.

Example error behavior was:
* put cursor at the end of the marked text
* toggle marks
* enter text

expected:
text is being added without toggled marks

actual:
text is added with those marks applied

#### Is this adding or improving a _feature_ or fixing a _bug_?

<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [ ] The new code matches the existing patterns and styles.
* [ ] The tests pass with `yarn test`.
* [ ] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [ ] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
